### PR TITLE
fix: trigger release workflow only via workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
 
 jobs:
   goreleaser:


### PR DESCRIPTION
This PR updates the release workflow to be triggered only via workflow_dispatch to prevent multiple executions.